### PR TITLE
Add Chi middleware

### DIFF
--- a/chi/logger.go
+++ b/chi/logger.go
@@ -1,0 +1,39 @@
+package chi
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/middleware"
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+)
+
+// Logger returns a middleware to log HTTP requests.
+func Logger(logger log.Logger) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			start := time.Now()
+
+			ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
+			next.ServeHTTP(ww, r)
+
+			keyvals := []interface{}{
+				"request", middleware.GetReqID(r.Context()),
+				"proto", r.Proto,
+				"method", r.Method,
+				"status", ww.Status(),
+				"content", r.Header.Get("Content-Type"),
+				"path", r.URL.Path,
+				"duration", time.Since(start),
+				"bytes", ww.BytesWritten(),
+			}
+
+			if ww.Status()/100 == 5 {
+				level.Warn(logger).Log(keyvals...)
+				return
+			}
+			level.Debug(logger).Log(keyvals...)
+		})
+	}
+}

--- a/chi/prometheus.go
+++ b/chi/prometheus.go
@@ -1,0 +1,58 @@
+package chi
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/middleware"
+	"github.com/prometheus/client_golang/prometheus"
+
+	middlewareprom "github.com/kakkoyun/middleware/prometheus"
+)
+
+// Instrumentation returns a new Prometheus middleware for Chi.
+func Instrumentation(reg prometheus.Registerer, name string) func(next http.Handler) http.Handler {
+	ins := middlewareprom.New(reg, name)
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			start := time.Now()
+			ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
+			next.ServeHTTP(ww, r)
+
+			// https://godoc.org/github.com/go-chi/chi#Context.RoutePattern
+			routePattern := chi.RouteContext(r.Context()).RoutePattern()
+
+			ins.RequestDuration.WithLabelValues(http.StatusText(ww.Status()), routePattern, r.Method).Observe(time.Since(start).Seconds())
+			ins.RequestSize.WithLabelValues(http.StatusText(ww.Status()), routePattern, r.Method).Observe(float64(computeApproximateRequestSize(r)))
+			ins.RequestsTotal.WithLabelValues(http.StatusText(ww.Status()), routePattern, r.Method).Inc()
+			ins.ResponseSize.WithLabelValues(http.StatusText(ww.Status()), routePattern, r.Method).Observe(float64(ww.BytesWritten()))
+		})
+	}
+}
+
+// https://github.com/prometheus/client_golang/blob/06b1a0a6ae29dd8b39953dc7f1954a0b2fd680be/prometheus/promhttp/instrument_server.go#L298:6
+func computeApproximateRequestSize(r *http.Request) int {
+	s := 0
+	if r.URL != nil {
+		s += len(r.URL.String())
+	}
+
+	s += len(r.Method)
+	s += len(r.Proto)
+	for name, values := range r.Header {
+		s += len(name)
+		for _, value := range values {
+			s += len(value)
+		}
+	}
+	s += len(r.Host)
+
+	// N.B. r.Form and r.MultipartForm are assumed to be included in r.URL.
+
+	if r.ContentLength != -1 {
+		s += int(r.ContentLength)
+	}
+	return s
+}

--- a/examples/chi/main.go
+++ b/examples/chi/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/go-chi/chi"
+	middlewarechi "github.com/go-chi/chi/middleware"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/common/version"
+
+	middleware "github.com/kakkoyun/middleware/chi"
+	"github.com/kakkoyun/middleware/logger"
+)
+
+func main() {
+	l := logger.NewLogger("debug", logger.LogFormatLogfmt, "example")
+	defer level.Info(l).Log("msg", "exiting")
+
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(
+		version.NewCollector("middleware_chi_example"),
+		prometheus.NewGoCollector(),
+		prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}),
+	)
+
+	r := chi.NewRouter()
+	r.Use(middlewarechi.RequestID)
+	r.Use(middlewarechi.RealIP)
+	r.Use(middlewarechi.Recoverer)
+	r.Use(middlewarechi.StripSlashes)
+	r.Use(middleware.Logger(l))
+	r.Use(middleware.Instrumentation(reg, "middleware_chi_example"))
+
+	r.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
+	r.Get("/200", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	r.Get("/401", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get("/api/200", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		r.Get("/api/401", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		})
+	})
+
+	level.Info(l).Log("msg", "listening")
+	log.Fatal(http.ListenAndServe(":8080", r))
+}


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>


Output for metrics:
```console

# HELP http_request_duration_seconds Tracks the latencies for HTTP requests.
# TYPE http_request_duration_seconds histogram
http_request_duration_seconds_bucket{code="OK",handler="/200",method="GET",server="middleware_chi_example",le="0.001"} 1
http_request_duration_seconds_bucket{code="OK",handler="/200",method="GET",server="middleware_chi_example",le="0.01"} 1
http_request_duration_seconds_sum{code="OK",handler="/200",method="GET",server="middleware_chi_example"} 2.9758e-05
http_request_duration_seconds_count{code="OK",handler="/200",method="GET",server="middleware_chi_example"} 1
http_request_duration_seconds_bucket{code="OK",handler="/api/200",method="GET",server="middleware_chi_example",le="0.001"} 1
http_request_duration_seconds_bucket{code="OK",handler="/api/200",method="GET",server="middleware_chi_example",le="0.01"} 1
http_request_duration_seconds_sum{code="OK",handler="/api/200",method="GET",server="middleware_chi_example"} 6.1243e-05
http_request_duration_seconds_count{code="OK",handler="/api/200",method="GET",server="middleware_chi_example"} 1
http_request_duration_seconds_bucket{code="OK",handler="/metrics",method="GET",server="middleware_chi_example",le="0.001"} 1
http_request_duration_seconds_bucket{code="OK",handler="/metrics",method="GET",server="middleware_chi_example",le="0.01"} 1
http_request_duration_seconds_sum{code="OK",handler="/metrics",method="GET",server="middleware_chi_example"} 0.000661844
http_request_duration_seconds_count{code="OK",handler="/metrics",method="GET",server="middleware_chi_example"} 1
http_request_duration_seconds_bucket{code="Unauthorized",handler="/401",method="GET",server="middleware_chi_example",le="0.001"} 1
http_request_duration_seconds_bucket{code="Unauthorized",handler="/401",method="GET",server="middleware_chi_example",le="0.01"} 1
http_request_duration_seconds_sum{code="Unauthorized",handler="/401",method="GET",server="middleware_chi_example"} 3.6321e-05
http_request_duration_seconds_count{code="Unauthorized",handler="/401",method="GET",server="middleware_chi_example"} 1
http_request_duration_seconds_bucket{code="Unauthorized",handler="/api/401",method="GET",server="middleware_chi_example",le="0.001"} 1
http_request_duration_seconds_bucket{code="Unauthorized",handler="/api/401",method="GET",server="middleware_chi_example",le="0.01"} 1
http_request_duration_seconds_sum{code="Unauthorized",handler="/api/401",method="GET",server="middleware_chi_example"} 3.0443e-05
http_request_duration_seconds_count{code="Unauthorized",handler="/api/401",method="GET",server="middleware_chi_example"} 1
# HELP http_request_size_bytes Tracks the size of HTTP requests.
# TYPE http_request_size_bytes summary
http_request_size_bytes_sum{code="OK",handler="/200",method="GET",server="middleware_chi_example"} 59
http_request_size_bytes_count{code="OK",handler="/200",method="GET",server="middleware_chi_example"} 1
http_request_size_bytes_sum{code="OK",handler="/api/200",method="GET",server="middleware_chi_example"} 63
http_request_size_bytes_count{code="OK",handler="/api/200",method="GET",server="middleware_chi_example"} 1
http_request_size_bytes_sum{code="OK",handler="/metrics",method="GET",server="middleware_chi_example"} 63
http_request_size_bytes_count{code="OK",handler="/metrics",method="GET",server="middleware_chi_example"} 1
http_request_size_bytes_sum{code="Unauthorized",handler="/401",method="GET",server="middleware_chi_example"} 59
http_request_size_bytes_count{code="Unauthorized",handler="/401",method="GET",server="middleware_chi_example"} 1
http_request_size_bytes_sum{code="Unauthorized",handler="/api/401",method="GET",server="middleware_chi_example"} 63
http_request_size_bytes_count{code="Unauthorized",handler="/api/401",method="GET",server="middleware_chi_example"} 1
# HELP http_requests_total Tracks the number of HTTP requests.
# TYPE http_requests_total counter
http_requests_total{code="OK",handler="/200",method="GET",server="middleware_chi_example"} 1
http_requests_total{code="OK",handler="/api/200",method="GET",server="middleware_chi_example"} 1
http_requests_total{code="OK",handler="/metrics",method="GET",server="middleware_chi_example"} 1
http_requests_total{code="Unauthorized",handler="/401",method="GET",server="middleware_chi_example"} 1
http_requests_total{code="Unauthorized",handler="/api/401",method="GET",server="middleware_chi_example"} 1
# HELP http_response_size_bytes Tracks the size of HTTP responses.
# TYPE http_response_size_bytes summary
http_response_size_bytes_sum{code="OK",handler="/200",method="GET",server="middleware_chi_example"} 0
http_response_size_bytes_count{code="OK",handler="/200",method="GET",server="middleware_chi_example"} 1
http_response_size_bytes_sum{code="OK",handler="/api/200",method="GET",server="middleware_chi_example"} 0
http_response_size_bytes_count{code="OK",handler="/api/200",method="GET",server="middleware_chi_example"} 1
http_response_size_bytes_sum{code="OK",handler="/metrics",method="GET",server="middleware_chi_example"} 4846
http_response_size_bytes_count{code="OK",handler="/metrics",method="GET",server="middleware_chi_example"} 1
http_response_size_bytes_sum{code="Unauthorized",handler="/401",method="GET",server="middleware_chi_example"} 0
http_response_size_bytes_count{code="Unauthorized",handler="/401",method="GET",server="middleware_chi_example"} 1
http_response_size_bytes_sum{code="Unauthorized",handler="/api/401",method="GET",server="middleware_chi_example"} 0
http_response_size_bytes_count{code="Unauthorized",handler="/api/401",method="GET",server="middleware_chi_example"} 1
# HELP middleware_chi_example_bui
```

Output for Logs:
```console
level=info name=example ts=2020-11-08T12:50:52.231933Z caller=main.go:53 msg=listening
level=debug name=example ts=2020-11-08T12:50:55.963027Z caller=logger.go:36 request=MacBook-Pro/ezUSHuSFuQ-000001 proto=HTTP/1.1 method=GET status=200 content= path=/metrics duration=689.486µs bytes=4846
level=debug name=example ts=2020-11-08T12:51:04.199682Z caller=logger.go:36 request=MacBook-Pro/ezUSHuSFuQ-000002 proto=HTTP/1.1 method=GET status=200 content= path=/200 duration=43.174µs bytes=0
level=debug name=example ts=2020-11-08T12:51:06.840198Z caller=logger.go:36 request=MacBook-Pro/ezUSHuSFuQ-000003 proto=HTTP/1.1 method=GET status=401 content= path=/401 duration=46.927µs bytes=0
level=debug name=example ts=2020-11-08T12:51:10.263854Z caller=logger.go:36 request=MacBook-Pro/ezUSHuSFuQ-000004 proto=HTTP/1.1 method=GET status=401 content= path=/api/401 duration=41.876µs bytes=0
level=debug name=example ts=2020-11-08T12:51:14.740294Z caller=logger.go:36 request=MacBook-Pro/ezUSHuSFuQ-000005 proto=HTTP/1.1 method=GET status=200 content= path=/api/200 duration=74.561µs bytes=0
level=debug name=example ts=2020-11-08T12:51:17.829373Z caller=logger.go:36 request=MacBook-Pro/ezUSHuSFuQ-000006 proto=HTTP/1.1 method=GET status=200 content= path=/metrics duration=408.446µs bytes=18519
```